### PR TITLE
Added portable mode (no database, no file cache)

### DIFF
--- a/ajaxPHP/ajax.search.php
+++ b/ajaxPHP/ajax.search.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once __DIR__."/../conf/config.php";
 require_once __DIR__."/../class/class.Search.php";
 require_once __DIR__."/../class/class.ErrorHandler.php";
 require_once __DIR__."/../class/class.Pagination.php";
@@ -29,5 +30,16 @@ $return = Array(
     "pagination" => (string)$pagination,
     "error" => $error->getAllAsJSONReady()
 );
+
+if (PORTABLE_MODE)
+{
+    $error->addNew(ErrorCode::ERROR_WARNING, "No search available - This server runs in portable mode");
+
+    $return = Array(
+        "count" => $search->getTotalCount(),
+        "pagination" => (string)$pagination,
+        "error" => $error->getAllAsJSONReady()
+    );
+}
 
 echo json_encode($return);

--- a/class/class.Search.php
+++ b/class/class.Search.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__."/../conf/config.php";
 require_once __DIR__."/class.dbHandler.php";
 require_once __DIR__."/class.Utils.php";
 
@@ -89,6 +90,12 @@ class Search
 
     private function search($searchFor, $currentPage, $limit)
     {
+        if (PORTABLE_MODE) {
+            $this->totalCount = 0;
+            $this->results = Array();
+            return true;
+        }
+
         try
         {
             $db = new dbHandler();

--- a/conf/config.php
+++ b/conf/config.php
@@ -1,0 +1,7 @@
+<?php
+// Nothing to see here
+
+// With portable mode enabled no files are cached
+// this means the databse is not used
+// and files are deleted from the hard drive after they have been downloaded
+define("PORTABLE_MODE", false);

--- a/download.php
+++ b/download.php
@@ -1,5 +1,6 @@
 <?php
 ob_start();
+require_once("conf/config.php");
 require_once("class/class.dbHandler.php");
 require_once("class/class.Download.php");
 
@@ -69,5 +70,9 @@ header("Content-Length: " . filesize("archive/". $fileInfos->getFilename()));
 header('Content-Disposition: attachment; filename="'. $fileInfos->getTitle() .' - '. $fileInfos->getAuthor() .'.'. $filetype .'"');
 header("Content-Transfer-Encoding: binary");
 readfile("archive/". $fileInfos->getFilename());
+
+if (PORTABLE_MODE) {
+    unlink("archive/" . $fileInfos->getFilename());
+}
 
 ob_end_flush();

--- a/index.php
+++ b/index.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__."/conf/config.php"; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -76,9 +77,11 @@
                                 <option value="arial">Arial</option>
                             </select>-->
 
-                            <div class="checkbox">
-                                <label><input id="force-update" type="checkbox">Force update</label>
-                            </div>
+                            <?php if (! PORTABLE_MODE): ?>
+                                <div class="checkbox">
+                                    <label><input id="force-update" type="checkbox">Force update</label>
+                                </div>
+                            <?php endif; ?>
 
                             <div class="checkbox">
                                 <label><input id="auto-dl" type="checkbox" checked="checked">Automatic Download</label>

--- a/sqlSession.php
+++ b/sqlSession.php
@@ -1,13 +1,18 @@
 <?php
-require_once("../class/class.sessionHandler.php");
+require_once("conf/config.php");
 
-$session = new Session();
+// if in poprtable mode - use default php sessions
+if (! PORTABLE_MODE) {
+    require_once("../class/class.sessionHandler.php");
 
-session_set_save_handler(
-    Array($session, "open"),
-    Array($session, "close"),
-    Array($session, "read"),
-    Array($session, "write"),
-    Array($session, "destroy"),
-    Array($session, "clean")
-);
+    $session = new Session();
+
+    session_set_save_handler(
+        Array($session, "open"),
+        Array($session, "close"),
+        Array($session, "read"),
+        Array($session, "write"),
+        Array($session, "destroy"),
+        Array($session, "clean")
+    );
+}


### PR DESCRIPTION
Hey,

I wanted to use this without a database and without it storing all the files on m server.
So I added a `PORTABLE_MODE`. If this option is enabled in the _config.php_:
- the database is **not** used/needed - everything lives in normal php sessions
- files are deleted after they have been downloaded

I don't think that will partically useful for your server, but perhaps someone else wants to use your project on a smaller, private server...

&nbsp;
Regards
 ~ Mike
