### PR TITLE
[PHP7.1+] Fix changed session management

### DIFF
--- a/class/class.sessionHandler.php
+++ b/class/class.sessionHandler.php
@@ -47,6 +47,7 @@ class Session
 
                 return $result["data"];
             }
+            return '';
         }
         catch (PDOException $e)
         {
@@ -90,7 +91,7 @@ class Session
         try
         {
             $old = time() - $max;
-            $query = $this->pdo->prepare("DELETE FROM `sessions` SHERE `access` < ?;");
+            $query = $this->pdo->prepare("DELETE FROM `sessions` WHERE `access` < ?;");
             $query->execute(Array($old));
         }
         catch (PDOException $e)


### PR DESCRIPTION
and fix typo in `clean()` SQL clause (was `SHERE` instead of `WHERE`)

PHP 7.1+ does not allow NULL/FALSE/TRUE return in session read, requires empty string instead, if no suitable record is found.